### PR TITLE
[PRODSEC-8543] Deprecate Gem-proxy.chime.com

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source 'https://gem-proxy.chime.com'
+source 'https://rubygems.org'
 
 # Specify your gem's dependencies in rails-properties.gemspec
 gemspec

--- a/ci/Gemfile-rails-3-1
+++ b/ci/Gemfile-rails-3-1
@@ -1,4 +1,4 @@
-source 'https://gem-proxy.chime.com'
+source 'https://rubygems.org'
 
 gem 'activerecord', '~> 3.1.12'
 

--- a/ci/Gemfile-rails-3-2
+++ b/ci/Gemfile-rails-3-2
@@ -1,4 +1,4 @@
-source 'https://gem-proxy.chime.com'
+source 'https://rubygems.org'
 
 gem 'activerecord', '~> 3.2.22'
 

--- a/ci/Gemfile-rails-4-0
+++ b/ci/Gemfile-rails-4-0
@@ -1,4 +1,4 @@
-source 'https://gem-proxy.chime.com'
+source 'https://rubygems.org'
 
 gem 'activerecord', '~> 4.0.13'
 gem 'protected_attributes' if ENV['PROTECTED_ATTRIBUTES'] == 'true'

--- a/ci/Gemfile-rails-4-1
+++ b/ci/Gemfile-rails-4-1
@@ -1,4 +1,4 @@
-source 'https://gem-proxy.chime.com'
+source 'https://rubygems.org'
 
 gem 'activerecord', '~> 4.1.10'
 gem 'protected_attributes' if ENV['PROTECTED_ATTRIBUTES'] == 'true'

--- a/ci/Gemfile-rails-4-2
+++ b/ci/Gemfile-rails-4-2
@@ -1,4 +1,4 @@
-source 'https://gem-proxy.chime.com'
+source 'https://rubygems.org'
 
 gem 'activerecord', '~> 4.2.1'
 gem 'protected_attributes' if ENV['PROTECTED_ATTRIBUTES'] == 'true'

--- a/ci/Gemfile-rails-5-0
+++ b/ci/Gemfile-rails-5-0
@@ -1,4 +1,4 @@
-source 'https://gem-proxy.chime.com'
+source 'https://rubygems.org'
 
 gem 'activerecord', '~> 5.0.0'
 

--- a/ci/Gemfile-rails-5-1
+++ b/ci/Gemfile-rails-5-1
@@ -1,4 +1,4 @@
-source 'https://gem-proxy.chime.com'
+source 'https://rubygems.org'
 
 gem 'activerecord', '~> 5.1.0'
 

--- a/ci/Gemfile-rails-5-2
+++ b/ci/Gemfile-rails-5-2
@@ -1,4 +1,4 @@
-source 'https://gem-proxy.chime.com'
+source 'https://rubygems.org'
 
 gem 'activerecord', '~> 5.2.0.rc1'
 


### PR DESCRIPTION
This PR is made to deprecate Gem-proxy.chime.com. This PR will replace gem-proxy.chime.com with Rubygems.org as a public Ruby Gems registry.

[_Created by Sourcegraph batch change `mazen160/Deprecate-gem-proxy-1`._](https://chime.sourcegraph.com/users/mazen160/batch-changes/Deprecate-gem-proxy-1)