### PR TITLE
Filter properties in the database instead of in memory

### DIFF
--- a/lib/rails-properties.rb
+++ b/lib/rails-properties.rb
@@ -1,12 +1,3 @@
-module RailsProperties
-  # In Rails 3, attributes can be protected by `attr_accessible` and `attr_protected`
-  # In Rails 4, attributes can be protected by using the gem `protected_attributes`
-  # In Rails 5, protecting attributes is obsolete (there are `StrongParameters` only)
-  def self.can_protect_attributes?
-    (ActiveRecord::VERSION::MAJOR == 3) || defined?(ProtectedAttributes)
-  end
-end
-
 require 'rails-properties/property_object'
 require 'rails-properties/configuration'
 require 'rails-properties/base'

--- a/lib/rails-properties/base.rb
+++ b/lib/rails-properties/base.rb
@@ -12,7 +12,7 @@ module RailsProperties
           raise ArgumentError unless var.is_a?(Symbol)
           raise ArgumentError.new("Unknown key: #{var}") unless self.class.default_properties[var]
 
-          property_objects.detect { |s| s.var == var.to_s }  || property_objects.build(:var => var.to_s, :target => self)
+          cached_properties[var] ||= property_objects.find_or_initialize_by(var: var)
         end
 
         def properties=(value)
@@ -37,6 +37,12 @@ module RailsProperties
             properties_hash[var] = properties_hash[var].merge(properties(var.to_sym).value)
           end
           properties_hash
+        end
+
+        private
+
+        def cached_properties
+          @cached_properties ||= {}
         end
       end
     end

--- a/lib/rails-properties/base.rb
+++ b/lib/rails-properties/base.rb
@@ -12,11 +12,7 @@ module RailsProperties
           raise ArgumentError unless var.is_a?(Symbol)
           raise ArgumentError.new("Unknown key: #{var}") unless self.class.default_properties[var]
 
-          if RailsProperties.can_protect_attributes?
-            property_objects.detect { |s| s.var == var.to_s } || property_objects.build({ :var => var.to_s }, :without_protection => true)
-          else
-            property_objects.detect { |s| s.var == var.to_s } || property_objects.build(:var => var.to_s, :target => self)
-          end
+          property_objects.detect { |s| s.var == var.to_s }  || property_objects.build(:var => var.to_s, :target => self)
         end
 
         def properties=(value)

--- a/lib/rails-properties/property_object.rb
+++ b/lib/rails-properties/property_object.rb
@@ -15,12 +15,6 @@ module RailsProperties
 
     serialize :value, Hash
 
-    if RailsProperties.can_protect_attributes?
-      # attr_protected can not be used here because it touches the database which is not connected yet.
-      # So allow no attributes and override <tt>#sanitize_for_mass_assignment</tt>
-      attr_accessible
-    end
-
     REGEX_SETTER = /\A([a-z]\w+)=\Z/i
     REGEX_GETTER = /\A([a-z]\w+)\Z/i
 
@@ -41,14 +35,6 @@ module RailsProperties
         else
           super
         end
-      end
-    end
-
-  protected
-    if RailsProperties.can_protect_attributes?
-      # Simulate attr_protected by removing all regular attributes
-      def sanitize_for_mass_assignment(attributes, role = nil)
-        attributes.except('id', 'var', 'value', 'target_id', 'target_type', 'created_at', 'updated_at')
       end
     end
 

--- a/lib/rails-properties/version.rb
+++ b/lib/rails-properties/version.rb
@@ -1,3 +1,3 @@
 module RailsProperties
-  VERSION = '3.4.3'
+  VERSION = '4.0.0'
 end

--- a/rails-properties.gemspec
+++ b/rails-properties.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'activerecord', '>= 3.1'
 
   gem.add_development_dependency 'rake'
-  gem.add_development_dependency 'sqlite3'
+  gem.add_development_dependency 'sqlite3', "~> 1.4"
   gem.add_development_dependency 'rspec'
   gem.add_development_dependency 'coveralls'
   gem.add_development_dependency 'simplecov', RUBY_VERSION < '2' ? '~> 0.11.2' : '>= 0.11.2'

--- a/rails-properties.gemspec
+++ b/rails-properties.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ['lib']
 
-  gem.add_dependency 'activerecord', '>= 3.1'
+  gem.add_dependency 'activerecord', '>= 6.0'
 
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'sqlite3', "~> 1.4"

--- a/spec/properties_spec.rb
+++ b/spec/properties_spec.rb
@@ -145,7 +145,7 @@ describe "Object without properties" do
   end
 
   it "should add properties" do
-    user.properties(:dashboard).update_attributes! :smart => true
+    user.properties(:dashboard).update! :smart => true
 
     user.reload
     expect(user.properties(:dashboard).smart).to eq(true)
@@ -179,7 +179,7 @@ describe "Object with properties" do
   end
 
   it "should update properties" do
-    user.properties(:dashboard).update_attributes! :smart => true
+    user.properties(:dashboard).update! :smart => true
     user.reload
 
     expect(user.properties(:dashboard).smart).to eq(true)

--- a/spec/properties_spec.rb
+++ b/spec/properties_spec.rb
@@ -246,3 +246,17 @@ describe "to_properties_hash" do
     expect(user.to_properties_hash).to eq({:dashboard=>{"theme"=>"green", "view"=>"monthly", "filter"=>true, "sound" => 11}, :calendar=>{"scope"=>"some"}})
   end
 end
+
+describe "reloading the target with unsaved property changes" do
+  let(:user) { User.create! }
+
+  before do
+    user.properties(:dashboard).theme = 'green'
+  end
+
+  it "should reset unsaved properties" do
+    user.reload
+    # blue is the default theme value
+    expect(user.properties(:dashboard).theme).to eq('blue')
+  end
+end

--- a/spec/property_object_spec.rb
+++ b/spec/property_object_spec.rb
@@ -105,7 +105,7 @@ describe RailsProperties::PropertyObject do
 
   describe "update_attributes" do
     it 'should save' do
-      expect(new_property_object.update_attributes(:foo => 42, :bar => 'string')).to be_truthy
+      expect(new_property_object.update(:foo => 42, :bar => 'string')).to be_truthy
       new_property_object.reload
 
       expect(new_property_object.foo).to eq(42)
@@ -115,7 +115,7 @@ describe RailsProperties::PropertyObject do
     end
 
     it 'should not save blank hash' do
-      expect(new_property_object.update_attributes({})).to be_truthy
+      expect(new_property_object.update({})).to be_truthy
     end
 
     if RailsProperties.can_protect_attributes?

--- a/spec/property_object_spec.rb
+++ b/spec/property_object_spec.rb
@@ -3,13 +3,8 @@ require 'spec_helper'
 describe RailsProperties::PropertyObject do
   let(:user) { User.create! :name => 'Mr. Pink' }
 
-  if RailsProperties.can_protect_attributes?
-    let(:new_property_object) { user.property_objects.build({ :var => 'dashboard'}, :without_protection => true) }
-    let(:saved_property_object) { user.property_objects.create!({ :var => 'dashboard', :value => { 'theme' => 'pink', 'filter' => false}}, :without_protection => true) }
-  else
-    let(:new_property_object) { user.property_objects.build({ :var => 'dashboard'}) }
-    let(:saved_property_object) { user.property_objects.create!({ :var => 'dashboard', :value => { 'theme' => 'pink', 'filter' => false}}) }
-  end
+  let(:new_property_object) { user.property_objects.build({ :var => 'dashboard'}) }
+  let(:saved_property_object) { user.property_objects.create!({ :var => 'dashboard', :value => { 'theme' => 'pink', 'filter' => false}}) }
 
   describe "serialization" do
     it "should have a hash default" do
@@ -116,15 +111,6 @@ describe RailsProperties::PropertyObject do
 
     it 'should not save blank hash' do
       expect(new_property_object.update({})).to be_truthy
-    end
-
-    if RailsProperties.can_protect_attributes?
-      it 'should not allow changing protected attributes' do
-        new_property_object.update_attributes!(:var => 'calendar', :foo => 42)
-
-        expect(new_property_object.var).to eq('dashboard')
-        expect(new_property_object.foo).to eq(42)
-      end
     end
   end
 

--- a/spec/queries_spec.rb
+++ b/spec/queries_spec.rb
@@ -51,7 +51,7 @@ describe 'Queries performed' do
         user.properties(:dashboard).bar = 'string'
         user.properties(:calendar).bar = 'string'
         user.save!
-      }.to perform_queries(3)
+      }.to perform_queries(4)
     end
   end
 

--- a/spec/queries_spec.rb
+++ b/spec/queries_spec.rb
@@ -94,7 +94,7 @@ describe 'Queries performed' do
 
     it "should update properties by one SQL query" do
       expect {
-        user.properties(:dashboard).update_attributes! :foo => 'bar'
+        user.properties(:dashboard).update! :foo => 'bar'
       }.to perform_queries(1)
     end
   end

--- a/spec/serialize_spec.rb
+++ b/spec/serialize_spec.rb
@@ -25,7 +25,7 @@ describe "Serialization" do
 
   describe 'updated properties' do
     it 'should be serialized' do
-      user.properties(:dashboard).update_attributes! :smart => true
+      user.properties(:dashboard).update! :smart => true
 
       dashboard_properties = user.property_objects.where(:var => 'dashboard').first
       calendar_properties = user.property_objects.where(:var => 'calendar').first


### PR DESCRIPTION
This PR has a few changes, but they were all motivated by changing how `RailsProperties::Base#properties` works. `#properties` accepts `var` as an argument and returns the target's matching property object. It has done this by fetching all of the targets property objects and filtering them in memory to find the requested `var`.

https://github.com/1debit/rails-properties/blob/e97fe12249e065c9d8f93c0185f441262c55d94b/lib/rails-properties/base.rb#L18

Although this filtering returns only one property object, the others are still loaded in memory and associated with the target. This can lead to strange side affects because callers aren't expecting the other objects to be loaded in memory. To fix this we can filter property objects at the database level so only the requested objects are loaded in memory.

```ruby
property_objects.find_or_initialize_by(var: var)
```

The [migration template](https://github.com/1debit/rails-properties/blob/e97fe12249e065c9d8f93c0185f441262c55d94b/lib/generators/rails_properties/migration/templates/migration.rb#L15) has an index on `target_type`, `target_id`, `var` so the database query should be performant.

To avoid conflicts when writing new property objects, memoize the requested property object after it's been initialized. This was done implicitly before when all the objects were loaded in memory. Without this memoization, test like [this](https://github.com/1debit/rails-properties/blob/e97fe12249e065c9d8f93c0185f441262c55d94b/spec/properties_spec.rb#L48-L50) fail.

Along with this change, we drop support for old versions of Rails. As a result, we can also remove `RailsProperties#can_protect_attributes?` and the related code. `#can_protect_attributes?` was used to support the Protected Attributes gem on old versions of Rails, and [Protected Attributes doesn't support Rails 5+](https://github.com/rails/protected_attributes/blob/a1e6dfd39cc106939a2f96ec98cfff4950eb3e7e/protected_attributes.gemspec#L21).