### PR TITLE
[CI-296] Update simplecov and cc-test-reporter version

### DIFF
--- a/rails-properties.gemspec
+++ b/rails-properties.gemspec
@@ -25,5 +25,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'sqlite3'
   gem.add_development_dependency 'rspec'
   gem.add_development_dependency 'coveralls'
-  gem.add_development_dependency 'simplecov', RUBY_VERSION < '2' ? '~> 0.11.2' : '>= 0.11.2'
+  gem.add_development_dependency 'simplecov', '>= 0.22'
 end


### PR DESCRIPTION
This updates the `cc-test-reporter` from the currently outdated default `0.7.0` version to `0.11.1` and along with that also the Simplecov version (see [instructions for the upgrade](https://www.notion.so/chimefinplat/Updating-SimpleCov-0e0b8a0b9edc4ec692da75590d3fb1fb?pvs=4) for reference).

The change also makes a few minor build related fixes:
* Fixes the Makefiles to replace `docker-compose` with `docker compose` as the former does not work with the latest Docker versions
* Removes deprecated `version` property and the "chm.life" network was created by DXT and no longer exists from the `docker-compose`
* Updates the `bundler` version to `2.5.18`
* Removes the `cit/security-scan` job as it has been replaced by Overwatch

[_Created by Sourcegraph batch change `maciej-chime/UpdateSimpleCov`._](https://chime.sourcegraph.com/users/maciej-chime/batch-changes/UpdateSimpleCov)