### PR TITLE
Add Rails 7.2+ support

### DIFF
--- a/ci/Gemfile-rails-7-1
+++ b/ci/Gemfile-rails-7-1
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gem 'activerecord', '~> 7.1.0'
+
+gemspec :path => "../"

--- a/ci/Gemfile-rails-7-2
+++ b/ci/Gemfile-rails-7-2
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gem 'activerecord', '~> 7.2.0'
+
+gemspec :path => "../"

--- a/lib/rails-properties/property_object.rb
+++ b/lib/rails-properties/property_object.rb
@@ -13,7 +13,11 @@ module RailsProperties
       end
     end
 
-    serialize :value, Hash
+    if ActiveRecord.version >= Gem::Version.new('7.1')
+      serialize :value, coder: YAML, type: Hash
+    else
+      serialize :value, Hash
+    end
 
     if RailsProperties.can_protect_attributes?
       # attr_protected can not be used here because it touches the database which is not connected yet.

--- a/lib/rails-properties/version.rb
+++ b/lib/rails-properties/version.rb
@@ -1,3 +1,3 @@
 module RailsProperties
-  VERSION = '3.4.3'
+  VERSION = '3.5.0'
 end

--- a/spec/properties_spec.rb
+++ b/spec/properties_spec.rb
@@ -145,7 +145,7 @@ describe "Object without properties" do
   end
 
   it "should add properties" do
-    user.properties(:dashboard).update_attributes! :smart => true
+    user.properties(:dashboard).update! :smart => true
 
     user.reload
     expect(user.properties(:dashboard).smart).to eq(true)
@@ -179,7 +179,7 @@ describe "Object with properties" do
   end
 
   it "should update properties" do
-    user.properties(:dashboard).update_attributes! :smart => true
+    user.properties(:dashboard).update! :smart => true
     user.reload
 
     expect(user.properties(:dashboard).smart).to eq(true)

--- a/spec/property_object_spec.rb
+++ b/spec/property_object_spec.rb
@@ -103,9 +103,9 @@ describe RailsProperties::PropertyObject do
     end
   end
 
-  describe "update_attributes" do
+  describe "update" do
     it 'should save' do
-      expect(new_property_object.update_attributes(:foo => 42, :bar => 'string')).to be_truthy
+      expect(new_property_object.update(:foo => 42, :bar => 'string')).to be_truthy
       new_property_object.reload
 
       expect(new_property_object.foo).to eq(42)
@@ -115,12 +115,12 @@ describe RailsProperties::PropertyObject do
     end
 
     it 'should not save blank hash' do
-      expect(new_property_object.update_attributes({})).to be_truthy
+      expect(new_property_object.update({})).to be_truthy
     end
 
     if RailsProperties.can_protect_attributes?
       it 'should not allow changing protected attributes' do
-        new_property_object.update_attributes!(:var => 'calendar', :foo => 42)
+        new_property_object.update!(:var => 'calendar', :foo => 42)
 
         expect(new_property_object.var).to eq('dashboard')
         expect(new_property_object.foo).to eq(42)

--- a/spec/queries_spec.rb
+++ b/spec/queries_spec.rb
@@ -94,7 +94,7 @@ describe 'Queries performed' do
 
     it "should update properties by one SQL query" do
       expect {
-        user.properties(:dashboard).update_attributes! :foo => 'bar'
+        user.properties(:dashboard).update! :foo => 'bar'
       }.to perform_queries(1)
     end
   end

--- a/spec/serialize_spec.rb
+++ b/spec/serialize_spec.rb
@@ -25,7 +25,7 @@ describe "Serialization" do
 
   describe 'updated properties' do
     it 'should be serialized' do
-      user.properties(:dashboard).update_attributes! :smart => true
+      user.properties(:dashboard).update! :smart => true
 
       dashboard_properties = user.property_objects.where(:var => 'dashboard').first
       calendar_properties = user.property_objects.where(:var => 'calendar').first


### PR DESCRIPTION
## Summary
- Update `serialize` API to use Rails 7.1+ keyword argument syntax (`coder:`, `type:`)
- Replace deprecated `update_attributes`/`update_attributes!` with `update`/`update!` in tests

Rails 7.1 and earlier are now EOL, so this gem should targets Rails 7.2+.